### PR TITLE
Fixed indexedCopy not generating subdirectories

### DIFF
--- a/src/main/kotlin/moe/nea/cittofirm/CitTransformer.kt
+++ b/src/main/kotlin/moe/nea/cittofirm/CitTransformer.kt
@@ -105,11 +105,12 @@ class CitTransformer(val source: Path, val target: Path, val repo: NEURepository
     }
 
     fun indexedCopy(path: Path, targetBucket: Path, transform: (Path, Path) -> Unit = { a, b -> a.copyTo(b) }): String {
-        val id = path.relativeTo(source.resolve("assets/minecraft")).toString()
-            .replace("/", "_").substringBeforeLast(".")
+        val id = path.relativeTo(source.resolve("assets/minecraft")).toString().substringBeforeLast(".")
         val ext = path.extension
         val t = targetBucket.resolve("$id.$ext")
         if (!t.exists()) {
+            if(!t.parent.exists())
+                t.createParentDirectories()
             val mcmeta = path.resolveSibling(path.name + ".mcmeta")
             if (mcmeta.exists()) {
                 mcmeta.copyTo(t.resolveSibling(t.name + ".mcmeta"))


### PR DESCRIPTION
Previously indexedCopy didn't generate directories for each item model/texture, which resulted in really long file names.
![image](https://github.com/FirmamentMC/CitToFirm/assets/78317238/a6dcfbe7-de45-4287-bac2-5f8929c4bbcc)
Now it properly generates subdirectories
![image](https://github.com/FirmamentMC/CitToFirm/assets/78317238/537c5b0e-3d1d-487f-b7e7-ebf69c72d372)
